### PR TITLE
Move away from unpaired parentheses in reviewer_checklist.md

### DIFF
--- a/.buffy/templates/reviewer_checklist.md
+++ b/.buffy/templates/reviewer_checklist.md
@@ -32,7 +32,7 @@
 - [ ] **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - [ ] **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?
 - [ ] **Automated tests:** Are there automated tests or manual steps described so that the functionality of the software can be verified?
-- [ ] **Community guidelines:** Are there clear guidelines for third parties wishing to 1) Contribute to the software 2) Report issues or problems with the software 3) Seek support
+- [ ] **Community guidelines:** Are there clear guidelines for third parties wishing to 1. Contribute to the software 2. Report issues or problems with the software 3. Seek support
 
 ### Software paper
 


### PR DESCRIPTION
The numbered list in the "community guidelines" entry used unclosed right parentheses which messes with certain text editor features, such as electric pairs when trying to enter a left parenthesis before this line, since it sees these as closing matches.

This switches them to periods instead.  Colons could also work.